### PR TITLE
Plausible.io tracking snippet for site analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
 
   <link rel='canonical' href="https://2077.xyz/" />
 
+  <script defer data-domain="2077.xyz" src="https://plausible.io/js/script.js"></script>
+
 </head>
 
 <body>


### PR DESCRIPTION
Ultimately, we want to know how many people vist 2077Collective websites, and have a dashboard like [this](https://plausible.io/plausible.io) which tracks important actions taken by visitors (e.g. clicked Discord link).

By inserting tracking snippet in < head > section, `Plausible.io` should be able to produce such dashboard for us. Plausible is mindful of privacy so it does not require cookie consent.

In the long run, we have a choice between cloud and self-hosted versions, but for now simplest solution is to host dashboard using cloud-hosted free-tier to confirm if tracking snippet will work at all.
